### PR TITLE
Remove compile warnings (and ignore one more autotools generated file).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache/
+compile
 config.h
 config.h.in
 config.log

--- a/src/diskio.c
+++ b/src/diskio.c
@@ -19,9 +19,6 @@ int disk_map(BYTE drive_number, volume_container *vol)
 
 DSTATUS disk_initialize (BYTE drv)
 {
-	DSTATUS stat;
-	int result;
-
 	return 0; /* status = success */
 }
 
@@ -34,9 +31,6 @@ DSTATUS disk_status (
 	BYTE drv		/* Physical drive nmuber (0..) */
 )
 {
-	DSTATUS stat;
-	int result;
-
 	return 0; /* status = success */
 }
 

--- a/src/hdfmonkey.c
+++ b/src/hdfmonkey.c
@@ -173,7 +173,6 @@ static void strip_trailing_slash(char *path) {
 }
 
 static int is_directory(char *path) {
-	int result;
 	struct stat fileinfo;
 	
 	if (stat(path, &fileinfo) != 0) {
@@ -338,7 +337,7 @@ static int put_file(char *source_filename, char *dest_filename) {
 			return -1;
 		}
 		
-		while (dir_entry = readdir(dir)) {
+		while ((dir_entry = readdir(dir))) {
 			if ( strcmp(dir_entry->d_name, ".") != 0 && strcmp(dir_entry->d_name, "..") != 0 ) {
 				source_child_filename = concat_filename(source_filename, dir_entry->d_name);
 				dest_child_filename = concat_filename(dest_filename, dir_entry->d_name);
@@ -381,6 +380,8 @@ static int put_file(char *source_filename, char *dest_filename) {
 		fclose(input_file);
 		f_close(&output_file);
 	}
+
+	return 0;
 }
 
 static int cmd_put(int argc, char *argv[]) {

--- a/src/image_file.c
+++ b/src/image_file.c
@@ -13,7 +13,7 @@ static ssize_t image_file_read(volume_container *v, off_t position, void *buf, s
 	int done = 0;
 	int res;
 	
-	if (res = lseek(fd, position + v->data.file.data_offset, SEEK_SET) < 0) {
+	if ((res = lseek(fd, position + v->data.file.data_offset, SEEK_SET)) < 0) {
 		return res;
 	}
 
@@ -36,7 +36,7 @@ static ssize_t image_file_write(volume_container *v, off_t position, void *buf, 
 	int done = 0;
 	int res;
 	
-	if (res = lseek(fd, position + v->data.file.data_offset, SEEK_SET) < 0) {
+	if ((res = lseek(fd, position + v->data.file.data_offset, SEEK_SET)) < 0) {
 		return res;
 	}
 


### PR DESCRIPTION
Most of these are harmless, but I'm slightly surprised the lack of return value from `put_file` didn't cause a problem somewhere.